### PR TITLE
Prevent linting errors when using eslint ^2.13.0

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  'extends': '.',
+  'extends': 'braintree',
   env: {
     browser: true,
     commonjs: true

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  'extends': '.',
+  'extends': 'braintree',
   env: {
     node: true
   }


### PR DESCRIPTION
[Eslint 2.13.0 made some changes to how relative paths work when extending](https://github.com/eslint/eslint/issues/6450), which caused any linting that [used our config to fail](https://travis-ci.org/braintree/braintree_express_example/builds/142899932). 

By referencing the package name instead in our sub-configs, we resolve this erroneous behavior. 

@braintree/front-end 
