### PR TITLE
One config to rule them all

### DIFF
--- a/jsdoc.js
+++ b/jsdoc.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'require-jsdoc': 2,
+    'valid-jsdoc': [2, {
+      prefer: {
+        return: 'returns'
+      },
+      requireReturn: false
+      requireParamDescription: true,
+      requireReturnDescription: true
+    }
+  }
+};

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -5,11 +5,11 @@ module.exports = {
     'require-jsdoc': 2,
     'valid-jsdoc': [2, {
       prefer: {
-        return: 'returns'
+        'return': 'returns'
       },
-      requireReturn: false
+      requireReturn: false,
       requireParamDescription: true,
       requireReturnDescription: true
-    }
+    }]
   }
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "mocha": "3.0.0"
+    "mocha": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/braintree/eslint-config.git"
   },
   "peerDependencies": {
-    "eslint": "^2.7.0"
+    "eslint": "^3.19.0"
   },
   "devDependencies": {
-    "eslint": "2.7.0",
+    "eslint": "3.19.0",
     "mocha": "3.0.0"
   }
 }

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -41,9 +41,6 @@ module.exports = {
     'no-new': 2,
     'no-octal-escape': 2,
     'no-octal': 2,
-    'no-param-reassign': [1, {
-      props: false
-    }],
     'no-process-env': 0,
     'no-proto': 2,
     'no-redeclare': 2,

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -7,7 +7,7 @@ module.exports = {
     complexity: 1,
     'consistent-return': 2,
     curly: [2, 'all'],
-    'default-case': 2,
+    'default-case': [2, { commentPattern: '^no default$' }],
     'dot-notation': [2, {allowKeywords: true}],
     'dot-location': [2, 'property'],
     eqeqeq: [2, 'allow-null'],
@@ -23,7 +23,11 @@ module.exports = {
     'no-extra-bind': 2,
     'no-fallthrough': 2,
     'no-floating-decimal': 2,
-    'no-implicit-coercion': [2, {string: true, number: true, 'boolean': true}],
+    'no-implicit-coercion': [2, {
+      string: true,
+      number: true,
+      boolean: true
+    }],
     'no-implied-eval': 2,
     'no-invalid-this': 2,
     'no-iterator': 2,
@@ -37,7 +41,9 @@ module.exports = {
     'no-new': 2,
     'no-octal-escape': 2,
     'no-octal': 2,
-    'no-param-reassign': 0,
+    'no-param-reassign': [1, {
+      'props': false
+    }],
     'no-process-env': 0,
     'no-proto': 2,
     'no-redeclare': 2,
@@ -50,7 +56,7 @@ module.exports = {
     'no-useless-call': 2,
     'no-useless-concat': 2,
     'no-void': 2,
-    'no-warning-comments': [1, {terms: ['todo', 'fixme'], location: 'anywhere'}],
+    'no-warning-comments': [1, {terms: ['todo', 'fixme', 'xxx'], location: 'anywhere'}],
     'no-with': 2,
     radix: 2,
     'vars-on-top': 2,

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -7,7 +7,7 @@ module.exports = {
     complexity: 1,
     'consistent-return': 2,
     curly: [2, 'all'],
-    'default-case': [2, { commentPattern: '^no default$' }],
+    'default-case': [2, {commentPattern: '^no default$'}],
     'dot-notation': [2, {allowKeywords: true}],
     'dot-location': [2, 'property'],
     eqeqeq: [2, 'allow-null'],
@@ -26,7 +26,7 @@ module.exports = {
     'no-implicit-coercion': [2, {
       string: true,
       number: true,
-      boolean: true
+      'boolean': true
     }],
     'no-implied-eval': 2,
     'no-invalid-this': 2,
@@ -42,7 +42,7 @@ module.exports = {
     'no-octal-escape': 2,
     'no-octal': 2,
     'no-param-reassign': [1, {
-      'props': false
+      props: false
     }],
     'no-process-env': 0,
     'no-proto': 2,

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -27,7 +27,6 @@ module.exports = {
     'no-sparse-arrays': 2,
     'no-unreachable': 2,
     'use-isnan': 2,
-    'valid-jsdoc': 2,
     'valid-typeof': 2,
     'no-unexpected-multiline': 2
   }

--- a/rules/style.js
+++ b/rules/style.js
@@ -21,17 +21,17 @@ module.exports = {
     'key-spacing': [2, {beforeColon: false, afterColon: true}],
     'keyword-spacing': [2],
     'lines-around-comment': [2, {
-      'allowArrayStart': true,
-      'allowBlockStart': true,
-      'allowObjectStart': true
+      allowArrayStart: true,
+      allowBlockStart: true,
+      allowObjectStart: true
     }],
     'linebreak-style': [2, 'unix'],
     'max-nested-callbacks': 0,
     'new-cap': [2, {newIsCap: true, capIsNew: true}],
     'new-parens': 2,
     'max-len': [2, {
-      'code': 140,
-      'ignoreUrls': true
+      code: 140,
+      ignoreUrls: true
     }],
     'newline-before-return': 2,
     'newline-after-var': [2, 'always'],
@@ -39,6 +39,16 @@ module.exports = {
     'no-continue': 0,
     'no-inline-comments': 0,
     'no-lonely-if': 2,
+    'no-mixed-operators': [2, {
+      groups: [
+        ['+', '-', '*', '/', '%', '**'],
+        ['&', '|', '^', '~', '<<', '>>', '>>>'],
+        ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+        ['&&', '||'],
+        ['in', 'instanceof']
+      ],
+      allowSamePrecedence: false
+    }],
     'no-mixed-spaces-and-tabs': 2,
     'no-multiple-empty-lines': [2, {max: 1}],
     'no-nested-ternary': 2,
@@ -49,8 +59,12 @@ module.exports = {
     'no-ternary': 0,
     'no-trailing-spaces': 2,
     'no-underscore-dangle': 0,
-    'no-unneeded-ternary': 2,
+    'no-unneeded-ternary': [2, {defaultAssignment: false}],
+    'no-whitespace-before-property': 2,
     'object-curly-spacing': [2, 'never'],
+    'object-property-newline': [2, {
+      allowMultiplePropertiesPerLine: true
+    }],
     'one-var': [2, {uninitialized: 'always', initialized: 'never'}],
     'operator-assignment': [2, 'always'],
     'operator-linebreak': [2, 'after'],
@@ -65,7 +79,9 @@ module.exports = {
     'space-in-parens': [2, 'never'],
     'space-infix-ops': 2,
     'space-unary-ops': [2, {words: true, nonwords: false}],
-    'spaced-comment': [2, 'always'],
+    'spaced-comment': [2, 'always', {
+      exceptions: ['-', '+']
+    }],
     'wrap-regex': 0
   }
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -5,7 +5,9 @@ module.exports = {
     'array-bracket-spacing': [2, 'never'],
     'block-spacing': [2, 'always'],
     'brace-style': [2, '1tbs', {allowSingleLine: true}],
-    camelcase: 2,
+    camelcase: [2, {
+      properties: 'never'
+    }],
     'comma-spacing': [2, {before: false, after: true}],
     'comma-style': [2, 'last'],
     'computed-property-spacing': [2, 'never'],
@@ -18,11 +20,20 @@ module.exports = {
     indent: [2, 2, {SwitchCase: 1}],
     'key-spacing': [2, {beforeColon: false, afterColon: true}],
     'keyword-spacing': [2],
-    'lines-around-comment': 0,
+    'lines-around-comment': [2, {
+      'allowArrayStart': true,
+      'allowBlockStart': true,
+      'allowObjectStart': true
+    }],
     'linebreak-style': [2, 'unix'],
     'max-nested-callbacks': 0,
     'new-cap': [2, {newIsCap: true, capIsNew: true}],
     'new-parens': 2,
+    'max-len': [2, {
+      'code': 140,
+      'ignoreUrls': true
+    }],
+    'newline-before-return': 2,
     'newline-after-var': [2, 'always'],
     'no-array-constructor': 2,
     'no-continue': 0,

--- a/rules/style.js
+++ b/rules/style.js
@@ -20,17 +20,14 @@ module.exports = {
     indent: [2, 2, {SwitchCase: 1}],
     'key-spacing': [2, {beforeColon: false, afterColon: true}],
     'keyword-spacing': [2],
-    'lines-around-comment': [2, {
-      allowArrayStart: true,
-      allowBlockStart: true,
-      allowObjectStart: true
-    }],
     'linebreak-style': [2, 'unix'],
     'max-nested-callbacks': 0,
     'new-cap': [2, {newIsCap: true, capIsNew: true}],
     'new-parens': 2,
     'max-len': [2, {
       code: 140,
+      ignoreComments: true,
+      ignoreStrings: true,
       ignoreUrls: true
     }],
     'newline-before-return': 2,

--- a/server.js
+++ b/server.js
@@ -4,5 +4,8 @@ module.exports = {
   'extends': 'braintree',
   env: {
     node: true
+  },
+  rules: {
+    'no-path-concat': 2
   }
 };


### PR DESCRIPTION
First pass at unifying our 2 eslint configs.

This will require a major version bump.

* Adds a jsdoc strategy
* Updates Eslint version
* Allow no default case in switch if comment with "no default" is included
* Add `xxx` to warning comment check
* allow Object properties to not be camelcase
* Enforce a max line length (with exceptions for comments, lines with strings and lines with urls)
* Enforce a new line before a return statement
* Add no-mixed-operators rule
* Add `defaultAssignment: false` to `no-uneeded-ternary`
* Add `no-whitespace-before-property`
* Add `object-property-newline`
* Allow comments to not have spaces if followed by `-` or `+`
* Add rule to server strategy to require path module to be used with `__dirname`