### PR TITLE
Upgrade to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [Configuration File Formats](https://eslint.org/docs/user-guide/configuring#
 
 To override rules, add the new config under `rules` in your rc file. Be sure to properly override any options set by the parent. See [Extending Configuration Files](https://eslint.org/docs/user-guide/configuring#extending-configuration-files) for details.
 
-For exmaple, to change the `no-extra-parens` rule to warn instead of error:
+For example, to change the `no-extra-parens` rule to warn instead of error:
 
 ```yaml
 ---

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ See [Configuration File Formats](https://eslint.org/docs/user-guide/configuring#
 
 To override rules, add the new config under `rules` in your rc file. Be sure to properly override any options set by the parent. See [Extending Configuration Files](https://eslint.org/docs/user-guide/configuring#extending-configuration-files) for details.
 
-For example, to change the `no-extra-parens` rule to warn instead of error:
+For example, to change the `no-new-object` rule to warn instead of error:
 
 ```yaml
 ---
 extends: braintree/server
 rules:
-  no-extra-parens: 1
+  no-new-object: 1
 ```
 
 In another example, to allow end of line comments, you'd override the `'no-multi-spaces': [2, {"ignoreEOLComments": true}]` rule options:

--- a/README.md
+++ b/README.md
@@ -22,24 +22,18 @@ __default__
 ```yaml
 ---
 extends: braintree
-rules:
-  locally-overriden-rule: 1
 ```
 
 __browserify__
 ```yaml
 ---
 extends: braintree/client
-rules:
-  locally-overriden-rule: 1
 ```
 
 __node__
 ```yaml
 ---
 extends: braintree/server
-rules:
-  locally-overriden-rule: 1
 ```
 
 __browserify + es6__
@@ -48,8 +42,6 @@ __browserify + es6__
 extends:
   - braintree/client
   - braintree/es6
-rules:
-  locally-overriden-rule: 1
 ```
 
 You can specify a `.eslintrc` for a subdirectory to change the rules that are enforced. For instance, in a node project you could extend from `eslint-config-braintree/server` at the top-level, and `eslint-braintree-config/client` at the `public/.eslintrc` level.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To override rules, add the new config under `rules` in your rc file. Be sure to 
 For exmaple, to change the `no-extra-parens` rule to warn instead of error:
 
 ```yaml
-___
+---
 extends: braintree/server
 rules:
   no-extra-parens: 1
@@ -62,7 +62,7 @@ rules:
 In another example, to allow end of line comments, you'd override the `'no-multi-spaces': [2, {"ignoreEOLComments": true}]` rule options:
 
 ```yaml
-___
+---
 extends: braintree/server
 rules:
   no-multi-spaces:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ extends:
 
 You can specify a `.eslintrc` for a subdirectory to change the rules that are enforced. For instance, in a node project you could extend from `eslint-config-braintree/server` at the top-level, and `eslint-braintree-config/client` at the `public/.eslintrc` level.
 
+See [Configuration File Formats](https://eslint.org/docs/user-guide/configuring#configuration-file-formats) for information on all supported `.eslintrc` file formats.
+
 To override rules, add the new config under `rules` in your rc file. Be sure to properly override any options set by the parent. See [Extending Configuration Files](https://eslint.org/docs/user-guide/configuring#extending-configuration-files) for details.
 
-See [Configuration File Formats](https://eslint.org/docs/user-guide/configuring#configuration-file-formats) for information on all supported `.eslintrc` file formats.
+For exmaple, to change the `no-extra-parens` rule to warn instead of error:
+
+```yaml
+___
+extends: braintree/server
+rules:
+  no-extra-parens: 1
+```
+
+In another example, to allow end of line comments, you'd override the `'no-multi-spaces': [2, {"ignoreEOLComments": true}]` rule options:
+
+```yaml
+___
+extends: braintree/server
+rules:
+  no-multi-spaces:
+    - 2
+    - ignoreEOLComments: false
+```
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install the eslint config
 npm i -D eslint-config-braintree
 ```
 
-In your project's .eslintrc:
+In your project's `.eslintrc.*` (below is yaml):
 
 __default__
 ```yaml
@@ -45,3 +45,7 @@ extends:
 ```
 
 You can specify a `.eslintrc` for a subdirectory to change the rules that are enforced. For instance, in a node project you could extend from `eslint-config-braintree/server` at the top-level, and `eslint-braintree-config/client` at the `public/.eslintrc` level.
+
+To override rules, add the new config under `rules` in your rc file. Be sure to properly override any options set by the parent. See [Extending Configuration Files](https://eslint.org/docs/user-guide/configuring#extending-configuration-files) for details.
+
+See [Configuration File Formats](https://eslint.org/docs/user-guide/configuring#configuration-file-formats) for information on all supported `.eslintrc` file formats.

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'require-jsdoc': 2,
+    'valid-jsdoc': [2, {
+      prefer: {
+        'return': 'returns'
+      },
+      requireReturn: false,
+      requireParamDescription: true,
+      requireReturnDescription: true
+    }]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/braintree/eslint-config.git"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": "^4.8.0"
   },
   "devDependencies": {
-    "eslint": "^4.0.0",
+    "eslint": "^4.8.0",
     "mocha": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-braintree",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Braintree's ESLint configuration",
   "scripts": {
     "lint": "eslint .",
@@ -13,10 +13,10 @@
     "url": "https://github.com/braintree/eslint-config.git"
   },
   "peerDependencies": {
-    "eslint": "^2.7.0"
+    "eslint": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": "2.7.0",
+    "eslint": "^4.0.0",
     "mocha": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "eslint": "^4.10.0",
-    "mocha": "3.0.0"
+    "mocha": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/braintree/eslint-config.git"
   },
   "peerDependencies": {
-    "eslint": "^4.8.0"
+    "eslint": "^4.10.0"
   },
   "devDependencies": {
-    "eslint": "^4.8.0",
+    "eslint": "^4.10.0",
     "mocha": "3.0.0"
   }
 }

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -29,7 +29,7 @@ module.exports = {
     'no-iterator': 2,
     'no-lone-blocks': 2,
     'no-loop-func': 2,
-    'no-multi-spaces': 2,
+    'no-multi-spaces': [2, {"ignoreEOLComments": true}],
     'no-multi-str': 2,
     'no-native-reassign': 2,
     'no-new-func': 2,

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -29,7 +29,7 @@ module.exports = {
     'no-iterator': 2,
     'no-lone-blocks': 2,
     'no-loop-func': 2,
-    'no-multi-spaces': [2, {"ignoreEOLComments": true}],
+    'no-multi-spaces': [2, {ignoreEOLComments: true}],
     'no-multi-str': 2,
     'no-native-reassign': 2,
     'no-new-func': 2,

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -27,7 +27,6 @@ module.exports = {
     'no-sparse-arrays': 2,
     'no-unreachable': 2,
     'use-isnan': 2,
-    'valid-jsdoc': 2,
     'valid-typeof': 2,
     'no-unexpected-multiline': 2
   }

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -15,7 +15,7 @@ module.exports = {
     'no-empty': 2,
     'no-ex-assign': 2,
     'no-extra-boolean-cast': 2,
-    'no-extra-parens': [2, 'all'],
+    'no-extra-parens': [2, 'all', {nestedBinaryExpressions: false}],
     'no-extra-semi': 2,
     'no-func-assign': 2,
     'no-inner-declarations': [2, 'both'],

--- a/rules/style.js
+++ b/rules/style.js
@@ -23,11 +23,28 @@ module.exports = {
     'max-nested-callbacks': 0,
     'new-cap': [2, {newIsCap: true, capIsNew: true}],
     'new-parens': 2,
+    'max-len': [2, {
+      code: 140,
+      ignoreComments: true,
+      ignoreStrings: true,
+      ignoreUrls: true
+    }],
+    'newline-before-return': 2,
     'newline-after-var': [2, 'always'],
     'no-array-constructor': 2,
     'no-continue': 0,
     'no-inline-comments': 0,
     'no-lonely-if': 2,
+    'no-mixed-operators': [2, {
+      groups: [
+        ['+', '-', '*', '/', '%', '**'],
+        ['&', '|', '^', '~', '<<', '>>', '>>>'],
+        ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+        ['&&', '||'],
+        ['in', 'instanceof']
+      ],
+      allowSamePrecedence: false
+    }],
     'no-mixed-spaces-and-tabs': 2,
     'no-multiple-empty-lines': [2, {max: 1}],
     'no-nested-ternary': 2,
@@ -39,7 +56,11 @@ module.exports = {
     'no-trailing-spaces': 2,
     'no-underscore-dangle': 0,
     'no-unneeded-ternary': 2,
+    'no-whitespace-before-property': 2,
     'object-curly-spacing': [2, 'never'],
+    'object-property-newline': [2, {
+      allowMultiplePropertiesPerLine: true
+    }],
     'one-var': [2, {uninitialized: 'always', initialized: 'never'}],
     'operator-assignment': [2, 'always'],
     'operator-linebreak': [2, 'after'],
@@ -54,7 +75,9 @@ module.exports = {
     'space-in-parens': [2, 'never'],
     'space-infix-ops': 2,
     'space-unary-ops': [2, {words: true, nonwords: false}],
-    'spaced-comment': [2, 'always'],
+    'spaced-comment': [2, 'always', {
+      exceptions: ['-', '+']
+    }],
     'wrap-regex': 0
   }
 };

--- a/server.js
+++ b/server.js
@@ -4,5 +4,8 @@ module.exports = {
   'extends': 'braintree',
   env: {
     node: true
+  },
+  rules: {
+    'no-path-concat': 2
   }
 };


### PR DESCRIPTION
Upgrades eslint to require at least 4.10.0. Any of the breaking changes shouldn't effect these rules.