### PR TITLE
Add jest config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 ## unreleased
 _Breaking Changes_
-* Add jest config to __tests_ directories automatically
+* Add jest config to `__tests__` directories automatically
 
 ## 4.0.0
 _Breaking Changes_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ CHANGELOG
 =========
 ## unreleased
 _Breaking Changes_
+* Add jest config to __tests_ directories automatically
+
+## 4.0.0
+_Breaking Changes_
 * Update peer dependencies to require eslint@6
 
 ## 3.0.1

--- a/README.md
+++ b/README.md
@@ -129,3 +129,7 @@ rules:
   }
 }
 ```
+
+## Test Files
+
+By default, any files in a `__tests__` folder, whether at the top level of the directory or within another directory will be configured to be used in the [Jest](https://jestjs.io/) and ES2020 environments.

--- a/__tests__/.eslintrc
+++ b/__tests__/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "../es6",
-  "env": {
-    "jest": true
-  }
-}

--- a/index.js
+++ b/index.js
@@ -8,5 +8,9 @@ module.exports = {
     './rules/style',
     './rules/variables'
   ].map(require.resolve),
-  rules: { }
+  rules: { },
+  overrides: [{
+    files: ['**/__tests__/**/*.js'],
+    extends: './jest'
+  }]
 };

--- a/index.js
+++ b/index.js
@@ -11,6 +11,6 @@ module.exports = {
   rules: { },
   overrides: [{
     files: ['**/__tests__/**/*.js'],
-    extends: './jest'
+    'extends': './jest'
   }]
 };

--- a/jest.js
+++ b/jest.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+  env: {
+    jest: true,
+    es2020: true
+  },
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  }
+};


### PR DESCRIPTION
Automatically configure __tests__ directories to use `jest` config.

This should make the transition to moving the tests to `__tests__` directories within the source file directories easier, as we won't need to create a new eslintrc in each of the directories.

I think we need to consider this a breaking change, since it automatically changes the environment for certain folders. Unlikely to be a problem, so upgrading should be simple.