### PR TITLE
chore: update dependabot config and standardize CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-type: "development"
+        update-types:
+          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      security-updates:
-        applies-to: security-updates
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
     open-pull-requests-limit: 3
     allow:
       - dependency-type: "development"
         update-types:
           - "version-update:semver-minor"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: "Unit Tests"
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   build:
@@ -8,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
-          node-version: "18.x"
-      - run: npm install
+          node-version-file: .nvmrc
+      - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Summary of changes

- Enable grouped dependabot security updates
- Add version update rules (dev dependencies, minor semver, limit 3 open PRs)
- Standardize CI workflow to match repo standards (checkout@v6, setup-node@v6, `node-version-file`, `npm ci`, eslint)

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [ ] Tested and confirmed flows affected by this change are functioning as expected

## Authors

@adrmachado-public