### PR TITLE
ci: add ready_for_review trigger to PR validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - synchronize
       - labeled
+      - ready_for_review
 
 jobs:
   pr-title-check:


### PR DESCRIPTION
# Summary of changes

- Add `ready_for_review` to the `pull_request` event types in the PR validation workflow
- When a draft PR is converted to ready-for-review, GitHub fires the `ready_for_review` activity type. Without this type in the trigger list, the workflow never re-runs and PR validation checks stay permanently skipped.

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [ ] Tested and confirmed flows affected by this change are functioning as expected

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

@GoogilyBoogily

### Reviewers

@braintree/team-sdk-js