### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version-file: .nvmrc
       - run: npm ci


### PR DESCRIPTION
## Summary

- Pins GitHub Actions and reusable workflow references to full-length commit SHAs, per GitHub's secure-use guidance for third-party actions. SHA-pinned refs carry a trailing comment with the original tag/branch for readability.

## Checklist

- [ ] ~Added a changelog entry:~ N/A
- [ ] ~Relevant test coverage:~ N/A
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

@lvandenboom 

### Reviewers

@braintree/team-sdk-js